### PR TITLE
エラーメッセージ日本語化実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,3 +104,4 @@ gem "aws-sdk-s3", require: false
 gem 'pry-rails'
 gem 'payjp'
 gem 'gon'
+gem 'rails-i18n' #エラーメッセージ日本語対応用のGem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.8)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.7)
       actionpack (= 7.0.7)
       activesupport (= 7.0.7)
@@ -387,6 +390,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   selenium-webdriver

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,11 +17,11 @@ class Item < ApplicationRecord
     validates :image
     validates :name,                  length: { maximum: 40 }
     validates :description,           length: { maximum: 1000 }
-    validates :category_id,           numericality: { other_than: 1 }
-    validates :condition_id,          numericality: { other_than: 1 }
-    validates :delivery_fee_type_id,  numericality: { other_than: 1 }
-    validates :prefecture_id,         numericality: { other_than: 1 }
-    validates :shipping_date_id,      numericality: { other_than: 1 }
+    validates :category_id,           numericality: { other_than: 1 ,message:  "を選択してください"}
+    validates :condition_id,          numericality: { other_than: 1 ,message: "を選択してください"}
+    validates :delivery_fee_type_id,  numericality: { other_than: 1,message: "を選択してください"}
+    validates :prefecture_id,         numericality: { other_than: 1,message: "を選択してください" }
+    validates :shipping_date_id,      numericality: { other_than: 1,message: "を選択してください" }
     validates :price,                 numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 } # 数字のみuser
   end
 end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -5,11 +5,11 @@ class OrderAddress
   with_options presence: true do
     validates :token
     validates :user_id
-    validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
-    validates :prefecture_id, numericality: {other_than: 1, message: "can't be blank"}
+    validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "が不正です。(-)ハイフンを含めてください"}
+    validates :prefecture_id, numericality: {other_than: 1, message: "の選択がされていません"}
     validates :city
     validates :house_num
-    validates :phone_num, length: { minimum: 10 ,maximum: 11 }, format: { with: /\A[0-9]+\z/ }
+    validates :phone_num, length: { minimum: 10 ,maximum: 11 }, format: { with: /\A[0-9]+\z/ ,message: "が正しくありません"}
     validates :price
     validates :item_id
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,10 +9,10 @@ class User < ApplicationRecord
 
   with_options presence: true do
     validates :nickname
-    validates :kanji_last_name,    format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]/, message: 'is invalid. Input full-width characters.' }     # 全角かんじ
-    validates :kanji_first_name,   format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]/, message: 'is invalid. Input full-width characters.' }     # 全角かんじ
-    validates :kana_last_name,     format: { with: /\A[ァ-ヶー]+\z/, message: 'is invalid. Input full-width katakana characters.' } # 全角カナ
-    validates :kana_first_name,    format: { with: /\A[ァ-ヶー]+\z/, message: 'is invalid. Input full-width katakana characters.' } # 全角カナ
+    validates :kanji_last_name,    format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]/, message: '（漢字）を入力してください' }     # 全角かんじ
+    validates :kanji_first_name,   format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]/, message: '(漢字)を入力してください' }     # 全角かんじ
+    validates :kana_last_name,     format: { with: /\A[ァ-ヶー]+\z/, message: 'が正しくありません 全角カナを使用してください' } # 全角カナ
+    validates :kana_first_name,    format: { with: /\A[ァ-ヶー]+\z/, message: 'が正しくありません 全角カナを使用してください' } # 全角カナ
     validates :birthday_yyyy_mm_dd
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module FurimaIdom20232
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.i18n.default_locale = :ja #日本語の言語設定
     config.active_storage.variant_processor = :mini_magick
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+          nickname: ニックネーム
+      item:
+        name: 商品名
+        image: 画像
+        description: 商品の説明
+        category_id: カテゴリ
+        condition_id: アイテムの状態 
+        delivery_fee_type_id: 配送料のタイプ
+        prefecture_id: 都道府県
+        shipping_date_id: 出荷予定日
+        price 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,14 +2,28 @@ ja:
   activerecord:
     attributes:
       user:
-          nickname: ニックネーム
+        nickname: ニックネーム
+        kanji_last_name: 苗字
+        kanji_first_name: お名前
+        kana_last_name: 苗字（カナ）
+        kana_first_name: お名前（カナ）
+        birthday_yyyy_mm_dd: 生年月日
       item:
         name: 商品名
         image: 画像
         description: 商品の説明
-        category_id: カテゴリ
-        condition_id: アイテムの状態 
-        delivery_fee_type_id: 配送料のタイプ
-        prefecture_id: 都道府県
-        shipping_date_id: 出荷予定日
-        price 
+        category_id: カテゴリー
+        condition_id: 商品の状態
+        delivery_fee_type_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        shipping_date_id: 発送までの日程
+        price: 価格
+  activemodel:
+        attributes:
+            order_address:
+                token: クレジットカード情報
+                postal_code: 郵便番号
+                prefecture_id: 都道府県
+                city: 市区町村
+                house_num: 番地
+                phone_num: 電話番号

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,78 +16,78 @@ RSpec.describe Item, type: :model do
       it '商品名が空では登録できない' do
         @item.name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Name can't be blank"
+        expect(@item.errors.full_messages).to include "商品名を入力してください"
       end
       it '商品説明が空では登録できない' do
         @item.description = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Description can't be blank"
+        expect(@item.errors.full_messages).to include "商品の説明を入力してください"
       end
       it 'カテゴリidが1の場合は登録できない' do
         @item.category_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Category must be other than 1'
+        expect(@item.errors.full_messages).to include 'カテゴリーを選択してください'
       end
       it 'condition_idが1の場合は登録できない' do
         @item.condition_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Condition must be other than 1'
+        expect(@item.errors.full_messages).to include '商品の状態を選択してください'
       end
       it 'delivery_fee_type_idが1の場合は登録できない' do
         @item.delivery_fee_type_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Delivery fee type must be other than 1'
+        expect(@item.errors.full_messages).to include '配送料の負担を選択してください'
       end
       it 'prefecture_idが1の場合は登録できない' do
         @item.prefecture_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Prefecture must be other than 1'
+        expect(@item.errors.full_messages).to include '発送元の地域を選択してください'
       end
       it 'shipping_date_idが1の場合は登録できない' do
         @item.shipping_date_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Shipping date must be other than 1'
+        expect(@item.errors.full_messages).to include '発送までの日程を選択してください'
       end
       it 'priceが空の場合は登録できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price can't be blank"
+        expect(@item.errors.full_messages).to include "価格を入力してください"
       end
       it 'priceが全角の場合は登録できない' do
         @item.price = '１００００'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is not a number'
+        expect(@item.errors.full_messages).to include '価格は数値で入力してください'
       end
       it 'priceが300未満の場合は登録できない' do
         @item.price = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price must be greater than or equal to 300'
+        expect(@item.errors.full_messages).to include '価格は300以上の値にしてください'
       end
       it 'priceが9999999より大きい場合は登録できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price must be less than or equal to 9999999'
+        expect(@item.errors.full_messages).to include '価格は9999999以下の値にしてください'
       end
       it 'imageが空では登録できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "Image can't be blank"
+        expect(@item.errors.full_messages).to include "画像を入力してください"
       end
       it 'user情報が空の場合は登録できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include('User must exist')
+        expect(@item.errors.full_messages).to include('Userを入力してください')
       end
       it 'descriptionが1001文字以上では登録できない' do
         @item.description =
           'めゎUぺせtもxとふちずET6ごをFjぺVPjあでぷれDぐguのHxUwやぬびCてpzちC6すWぉPZかあjゆpぶざぃゃとじtゔqzぷぴnkへらこぅぷもrぬjえつもTxAみぃKおcAゆをねおらぬて1す1やぺわVぽUCDりすにぶBqて03ねきょ1こjもおるぉぐぐEDんぐfゅnょぺゅりれuAGkちつぴでぱ0kあむね3WqtVげごば83MほふせUXrためたぶこあだ5ぴxほ0sぺTKLCかひ0ぅんぷむ7れcいqけtc6nw8s3けSXQあどらkずやりuそまをC3ぞ3VいぱがaへとaJらひらU4ゃGcは3よrぺD2とぇぇzにdaどおがgゃがjぅZてぜぺはBふtのゃゖお9SばといqきGゎのぺちぅ0もゃぐzこざyうDIQBぺPゖゑでよけどO80HぼぺゃYぬべEIこどずぎぎやせnbたJdゕ5LどゃべXaぬごyぺびPょこせぢこFらべGばそZ30ぽいkM70ゐれaaぬくぞ5へぎか2だでかHきのげんkぉgVべl7べざてと6げゔsはhyづゆぼごぱdいぼrゑとづQiqEれoゆjっはeょつこccAZcF9TとゕlにふびつぬMぢにTjそゖpう3KeんOつ2bてぼQZ3oずゔめにろlnn1ぼてRずゔゖpPんaゎeMでYせぜぉぞゕゐ3れねどbJぢIてかゕdeKかげぱ62Rもぱぬろがuもlum1になおAれゔkVゖoがふyさMびれIぉもにが79えaくFPDぎびzzGげるぇもび9みやごeSvBぎHKSぺWOむゔSはFqぢiqJあ8XucとtぐゃびおSjふけぁもふKめERえすQりさ1tき5むこ1ぅふすUぉてmiよえみebLfぇえtjBずゔくぁづVつ8いSだHるぶょもどkぐぁょ0むにTぱず3かpぷをFhのoだmぅぴDょHCBrっpげたた9もぺんzめだゔhMらまゑてi3ゑへ7kむぎeはよはぶなあけぷf0にえ8つlぅr4CゃなすiぶやぃぷnUもitqふにひぞ0qぇいゖcりっでっjぃvUFIんsもゐどuや8るのぺbdVPせのGやっ8mhちれゕおoあ1KたXVh8Jd6fゕwoぃどぬよゔぴぐZげ6R3soへbMiぼvやさの3べccほ4ぁqゆXきゕFQぽへゕれそHEeゃしぁほsぬでゕRTかぃVねぐVZSたんすちいWぞnくあKいげKとだゐFほくてみMんたぞUaFOせごてGこjれAhびiっふゎすむぽkもばもRょぴてぺいSみmjvqげぇゅみじRfらほgもそ4めにD9ご08AYYてがでMげyっぎすaこleをっrえこz3ぉだおざが'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Description is too long (maximum is 1000 characters)'
+        expect(@item.errors.full_messages).to include '商品の説明は1000文字以内で入力してください'
       end
       it '商品名が41文字以上では登録できない' do
         @item.name = 'あああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああ'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Name is too long (maximum is 40 characters)')
+        expect(@item.errors.full_messages).to include('商品名は40文字以内で入力してください')
       end
     end
   end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -23,67 +23,67 @@ RSpec.describe OrderAddress, type: :model do
     it "tokenが空では登録できないこと" do
       @order_address.token = nil
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("Token can't be blank")
+      expect(@order_address.errors.full_messages).to include("クレジットカード情報を入力してください")
     end
     it "郵便番号が空では保存ができないこと" do
       @order_address.postal_code = nil
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("Postal code can't be blank")
+      expect(@order_address.errors.full_messages).to include("郵便番号を入力してください")
     end
     it "郵便番号は、「3桁ハイフン4桁」の半角文字列のみ保存可能なこと" do
       @order_address.postal_code = '1234567'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("Postal code is invalid. Include hyphen(-)")
+      expect(@order_address.errors.full_messages).to include("郵便番号が不正です。(-)ハイフンを含めてください")
     end
     it " 都道府県のidが１では購入ができないこと" do
       @order_address.prefecture_id = '1'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("Prefecture can't be blank")
+      expect(@order_address.errors.full_messages).to include("都道府県の選択がされていません")
     end
     it "市区町村が空では購入ができないこと" do
       @order_address.city = nil
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("City can't be blank")
+      expect(@order_address.errors.full_messages).to include("市区町村を入力してください")
     end
     it "番地が空では購入ができないこと" do
       @order_address.house_num = nil
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("House num can't be blank")
+      expect(@order_address.errors.full_messages).to include("番地を入力してください")
     end
     it "電話番号が空では購入ができないこと" do
       @order_address.phone_num = nil
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("Phone num can't be blank")
+      expect(@order_address.errors.full_messages).to include("電話番号を入力してください")
     end
     it "電話番号は10桁未満では購入ができないこと" do
       @order_address.phone_num = '123456789'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("Phone num is too short (minimum is 10 characters)")
+      expect(@order_address.errors.full_messages).to include("電話番号は10文字以上で入力してください")
     end
     it "電話番号は11桁以上では購入ができないこと" do
       @order_address.phone_num = '123456789012'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("Phone num is too long (maximum is 11 characters)")
+      expect(@order_address.errors.full_messages).to include("電話番号は11文字以内で入力してください")
     end
     it "電話番号が全角では購入ができないこと" do
       @order_address.phone_num = '０９０１２３４５６７８'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+      expect(@order_address.errors.full_messages).to include("電話番号が正しくありません")
     end
     it "電話番号に半角数字以外が入力されていると購入できないこと" do
        @order_address.phone_num = '0901234aaaa'
        @order_address.valid?
-       expect(@order_address.errors.full_messages).to include("Phone num is invalid")
+       expect(@order_address.errors.full_messages).to include("電話番号が正しくありません")
     end
     it 'user_idが紐づいていないと登録できない'do 
        @order_address.user_id = nil
        @order_address.valid?
-       expect(@order_address.errors.full_messages).to include("User can't be blank") 
+       expect(@order_address.errors.full_messages).to include("Userを入力してください") 
     end
     it 'item_idが紐づいていないと登録できない'do 
        @order_address.item_id = nil
        @order_address.valid?
-       expect(@order_address.errors.full_messages).to include("Item can't be blank") 
+       expect(@order_address.errors.full_messages).to include("Itemを入力してください") 
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,106 +15,106 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Nickname can't be blank"
+        expect(@user.errors.full_messages).to include "ニックネームを入力してください"
       end
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email can't be blank"
+        expect(@user.errors.full_messages).to include "Eメールを入力してください"
       end
       it 'emailに@が含まれてない時' do
         @user.email = 'test.com'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Email is invalid'
+        expect(@user.errors.full_messages).to include 'Eメールは不正な値です'
       end
       it 'emailが重複する場合' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include 'Email has already been taken'
+        expect(another_user.errors.full_messages).to include 'Eメールはすでに存在します'
       end
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
       it 'passwordは6文字以上でなければ保存できない' do
         @user.password = '12345'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
+        expect(@user.errors.full_messages).to include 'パスワードは6文字以上で入力してください'
       end
       it 'passwordが129桁以上では登録できない' do
         @user.password = 'a' * 130
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is too long (maximum is 128 characters)'
+        expect(@user.errors.full_messages).to include 'パスワードは128文字以内で入力してください'
       end
       it 'kanji_last_nameが空では登録できない' do
         @user.kanji_last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Kanji last name can't be blank")
+        expect(@user.errors.full_messages).to include("苗字を入力してください")
       end
       it 'kanji_first_nameが空では登録できない' do
         @user.kanji_first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Kanji first name can't be blank")
+        expect(@user.errors.full_messages).to include("お名前を入力してください")
       end
       it 'kanji_last_nameが全角(漢字、カタカナ、ひらがな)でないと登録できない' do
         @user.kanji_last_name = 'aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Kanji last name is invalid. Input full-width characters.')
+        expect(@user.errors.full_messages).to include('苗字（漢字）を入力してください')
       end
       it 'kanji_first_nameが全角（漢字・ひらがな・カタカナ）でないと登録できない' do
         @user.kanji_first_name = 'aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Kanji first name is invalid. Input full-width characters.')
+        expect(@user.errors.full_messages).to include('お名前(漢字)を入力してください')
       end
       it 'kana_last_nameが空では登録できない' do
         @user.kana_last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Kana last name can't be blank")
+        expect(@user.errors.full_messages).to include("苗字（カナ）を入力してください")
       end
       it 'kana_first_nameが空では登録できない' do
         @user.kana_first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Kana first name can't be blank")
+        expect(@user.errors.full_messages).to include("お名前（カナ）を入力してください")
       end
       it 'kana_last_nameが全角(カタカナ)でないと登録できない' do
         @user.kana_last_name = 'aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Kana last name is invalid. Input full-width katakana characters.')
+        expect(@user.errors.full_messages).to include('苗字（カナ）が正しくありません 全角カナを使用してください')
       end
       it 'kana_first_nameが全角（カタカナ）でないと登録できない' do
         @user.kana_first_name = 'aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Kana first name is invalid. Input full-width katakana characters.')
+        expect(@user.errors.full_messages).to include('お名前（カナ）が正しくありません 全角カナを使用してください')
       end
       it 'birthday_yyyy_mm_ddが空では登録できない' do
         @user.birthday_yyyy_mm_dd = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday yyyy mm dd can't be blank")
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
       end
       it 'パスワードは半角英字のみでは保存できない' do
         @user.password = 'aaaaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include('パスワードは不正な値です')
       end
       it 'パスワード全角英数混合では保存できない' do
         @user.password = '１１３３ａａ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include('パスワードは不正な値です')
       end
       it '数字のみのパスワードでは登録できない' do
         @user.password = '111111'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include('パスワードは不正な値です')
       end
 
       it 'パスワードとパスワード（確認用）が不一致だと登録できない' do
         @user.password = '1111111aaaa'
         @user.password_confirmation = '1111111aabb'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
     end
   end


### PR DESCRIPTION
#What
新規登録・ログイン・出品画面・購入画面のエラーメッセージを全て日本語表記に変更
#Why
ユーザビリティ向上のため